### PR TITLE
fix: nix run

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -42,5 +42,6 @@ in
       homepage = "https://github.com/fzakaria/nix-auto-follow";
       description = "Achieve nirvana through automatically following all flake inputs.";
       license = lib.licenses.mit;
+      mainProgram = "auto-follow";
     };
   }


### PR DESCRIPTION
Since `meta.mainProgram` is not set the example command from the readme is broken

![image](https://github.com/user-attachments/assets/ea4c625e-39e6-447c-93a7-ed089300106a)
