### PR TITLE
Implement sub-quadratic time node definition replacement.

### DIFF
--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -126,7 +126,7 @@ def update_flake_lock(flake_lock: LockFile) -> LockFile:
     # root.inputs = {"nixpkgs": "nixpkgs_3"}
     #
     # this generates {"nixpkgs": ["nixpkgs_1", "nixpkgs_2", "nixpkgs_3"]}
-    input_refs = {}
+    input_refs: dict[str, list[str]] = {}
     for node in flake_lock.nodes.values():
         if node.inputs is None:
             continue


### PR DESCRIPTION
Rather than scanning all lock nodes over and over again for those with inputs that match the root node's inputs, build a mapping of inputs -> references in a single pass so that the root node definition can be copied over them in a single pass.