### PR TITLE
Add support back for pytest

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -56,7 +56,7 @@ in
       ]
       ++ [pyright];
 
-    checkPhase = ''
+    postCheck = ''
       make lint
     '';
 


### PR DESCRIPTION
Accidentally overwrote checkPhase so the pytest hook was not running. Fix this so my linter runs in postCheck instead.

Wow; what a gotcha.