### PR TITLE
Make stdin read only if '-' is provided

### DIFF
--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -172,7 +172,7 @@ def start(
     )
     parser.add_argument(
         "filename",
-        help="The path to the flake.lock file.",
+        help="The path to the flake.lock file. '-' for stdin.",
         default="flake.lock",
         nargs="?",
     )
@@ -193,7 +193,7 @@ def start(
         args, namespace=ProgramArguments()
     )
 
-    if not stdin.isatty():
+    if program_args.filename == "-":
         input_data = stdin.read()
     else:
         # Read the content of the file
@@ -215,6 +215,8 @@ def start(
     )
 
     if program_args.in_place:
+        if program_args.filename == "-":
+            raise ValueError("Cannot use --in-place with stdin.")
         # Write the modified JSON back to the file
         with open(program_args.filename, "w") as f:
             f.write(modified_data + "\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,7 +96,7 @@ def test_simple_root_has_follow_flake() -> None:
 def test_full_start() -> None:
     with open("tests/fixtures/root_has_follow.json") as f:
         stdout = io.StringIO()
-        start(stdin=f, stdout=stdout)
+        start(args=["-"], stdin=f, stdout=stdout)
         flake_lock = LockFile.from_dict(json.loads(stdout.getvalue()))
         assert flake_lock.root == "root"
 


### PR DESCRIPTION
Running this in a GitHub check doesn't have a tty which was causing some UX oddness.

Do the thing I was trying to avoid and just check for '-' as a special filename to mean stdin.

Also check for `-i` if stdin is provided and fail sicne this does not make sense.

fixes #17