### PR TITLE
Support git type for auto-follow

### DIFF
--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -3,6 +3,7 @@ import json
 import sys
 from dataclasses import dataclass, field
 from typing import Any, TextIO
+from urllib.parse import urlencode
 
 
 @dataclass
@@ -48,6 +49,17 @@ class Node:
         rev_or_ref = next((x for x in [rev, ref] if x), "")
 
         match original["type"]:
+            case "git":
+                base_url = f"git+{original['url']}"
+                filtered_params = {
+                    k: (1 if v is True else 0 if v is False else v)
+                    for k, v in original.items()
+                    if k in ["rev", "ref", "submodules", "shallow"]
+                    and v not in (None, "")
+                }
+                query_string = urlencode(filtered_params)
+                full_url = f"{base_url}?{query_string}" if query_string else base_url
+                return full_url
             case "github":
                 return f"github:{original['owner']}/{original['repo']}{rev_or_ref}"
             case "gitlab":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,43 @@ from nix_auto_follow.cli import (
             ),
             "nixpkgs/nixos-unstable/23.11",
         ),
+        (
+            Node.from_dict(
+                {
+                    "original": {
+                        "type": "git",
+                        "submodules": True,
+                        "url": "https://github.com/kaeeraa/ayugram-desktop",
+                    }
+                }
+            ),
+            "git+https://github.com/kaeeraa/ayugram-desktop?submodules=1",
+        ),
+        (
+            Node.from_dict(
+                {
+                    "original": {
+                        "type": "git",
+                        "shallow": True,
+                        "url": "ssh://git@github.com/mslxl/scripts.git",
+                    }
+                }
+            ),
+            "git+ssh://git@github.com/mslxl/scripts.git?shallow=1",
+        ),
+        (
+            Node.from_dict(
+                {
+                    "original": {
+                        "type": "git",
+                        "ref": "main",
+                        "shallow": True,
+                        "url": "ssh://git@gitlab.com/akibahmed/sops-secrects.git",
+                    }
+                }
+            ),
+            "git+ssh://git@gitlab.com/akibahmed/sops-secrects.git?ref=main&shallow=1",
+        ),
     ],
 )
 def test_get_url_for_node(node: Node, expected_url: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,17 @@ from nix_auto_follow.cli import (
                 {
                     "original": {
                         "type": "git",
+                        "url": "https://github.com/kaeeraa/ayugram-desktop",
+                    }
+                }
+            ),
+            "git+https://github.com/kaeeraa/ayugram-desktop",
+        ),
+        (
+            Node.from_dict(
+                {
+                    "original": {
+                        "type": "git",
                         "submodules": True,
                         "url": "https://github.com/kaeeraa/ayugram-desktop",
                     }


### PR DESCRIPTION
Support the 'git' type.
Looks like the 'git' type supports the params that are part of fetchGit. We want to emit proper urls so lets handle the params accordingly.

fixes #20