### PR TITLE
Add support for tarball flake input type

### DIFF
--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -68,6 +68,8 @@ class Node:
                 return f"file:{original['path']}"
             case "indirect":
                 return f"{original['id']}{ref}{rev}"
+            case "tarball":
+                return f"{original['url']}"
             case _:
                 raise ValueError(f"Unknown type {original['type']}")
 


### PR DESCRIPTION
Anything from FlakeHub will be of the tarball type rather than git/github etc...

There's only the URL in "original" while "locked" contains hashes and a more specific URL (this is how they implement semver).