### PR TITLE
Do not exit on first failure when in check mode

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722519197,
-        "narHash": "sha256-VEdJmVU2eLFtLqCjTYJd1J7+Go8idAcZoT11IewFiRg=",
+        "lastModified": 1736061677,
+        "narHash": "sha256-DjkQPnkAfd7eB522PwnkGhOMuT9QVCZspDpJJYyOj60=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05405724efa137a0b899cce5ab4dde463b4fd30b",
+        "rev": "cbd8ec4de4469333c82ff40d057350c30e9f7d36",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -100,6 +100,7 @@ class LockFile:
 
 
 def check_lock_file(flake_lock: LockFile) -> bool:
+    success = True
 
     for name, node in flake_lock.nodes.items():
 
@@ -127,11 +128,11 @@ def check_lock_file(flake_lock: LockFile) -> bool:
                             f"Node {name} has input {key} pointing to {ref} which is not the same as {other_name}'s {other_key} which is {other_ref} in the lockfile."  # noqa: E501
                         )
                         print(
-                            f"Please add '{key}.url = \"{flake_lock.nodes[ref].get_url()}\"' or '{other_key}.url = \"{flake_lock.nodes[other_ref].get_url()}'"  # noqa: E501
+                            f"Please add '{key}.url = \"{flake_lock.nodes[ref].get_url()}\"' or '{other_key}.url = \"{flake_lock.nodes[other_ref].get_url()}\"'"  # noqa: E501
                         )  # noqa: E501
-                        return False
+                        success = False
 
-    return True
+    return success
 
 
 def update_flake_lock(flake_lock: LockFile) -> LockFile:


### PR DESCRIPTION
Prior check mode would bail out as soon as an error was encountered. This led to what looked like "false negatives"; since not everything was included.

The output is more verbose but will now include all non-follows.

fixes #26