### PR TITLE
Fix isort error on newer nixpkgs'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ write_to = "src/nix_auto_follow/_version.py"
 auto-follow = "nix_auto_follow.cli:start"
 
 [tool.isort]
-skip = [".git", "result"]
+skip = [".git", "result", "src/nix_auto_follow/_version.py"]
 profile = "black"
 
 [tool.black]


### PR DESCRIPTION
When trying this against a recent nixos-unstable revision the `make lint` step fails with the following error:

```
$ make lint
flake8 src/ tests/
isort --check src/ tests/
ERROR: .../nix-auto-follow/src/nix_auto_follow/_version.py Imports are incorrectly sorted and/or formatted.
make: *** [Makefile:24: lint] Error 1
(.venv)
```

I tried tracking it down with git bisect but it ended up on a staging merge and I could not make more progress with. This change is arguably correct/a good idea anyway.