### PR TITLE
Fix pygments for nixpkgs-unstable

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -36,6 +36,8 @@ in
         (python3Packages.buildPythonPackage rec {
           pname = "types-Pygments";
           version = "2.17.0.20240310";
+          pyproject = true;
+          build-system = [setuptools];
 
           src = python.pkgs.fetchPypi {
             inherit pname version;


### PR DESCRIPTION
Looks like some defaults have to be specified manually now for our custom build of pygments.

**25.05**
```
nix build --no-link --print-out-paths
warning: Git tree '/home/fmzakari/code/github.com/fzakaria/nix-auto-follow' is dirty
/nix/store/7f3v9dbi99ba1c5myy903rq52d2k71m3-nix-auto-follow
```

**unstable**
```
 nix build --override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-unstable --no-link  --print-out-paths
warning: Git tree '/home/fmzakari/code/github.com/fzakaria/nix-auto-follow' is dirty
warning: not writing modified lock file of flake 'git+file:///home/fmzakari/code/github.com/fzakaria/nix-auto-follow':
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/88983d4b665fb491861005137ce2b11a9f89f203?narHash=sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4%2Bf9C1mZQ%3D' (2025-07-08)
  → 'github:NixOS/nixpkgs/7c688a0875df5a8c28a53fb55ae45e94eae0dddb?narHash=sha256-vtTM4oDke3SeDj%2B1ey6DjmzXdq8ZZSCLWSaApADDvIE%3D' (2025-07-20)
/nix/store/3kppajh4g0930yk24rxb9mahlcqxpsgs-nix-auto-follow
```

fixes #29