### PR TITLE
fix inputs references

### DIFF
--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -123,7 +123,10 @@ def check_lock_file(flake_lock: LockFile) -> bool:
                     if key != other_key:
                         continue
 
-                    if flake_lock.nodes[ref] != flake_lock.nodes[other_ref]:
+                    # Compare only locked content, not inputs wiring
+                    node_locked = flake_lock.nodes[ref].remaining.get("locked")
+                    other_locked = flake_lock.nodes[other_ref].remaining.get("locked")
+                    if node_locked != other_locked:
                         print(
                             f"Node {name} has input {key} pointing to {ref} which is not the same as {other_name}'s {other_key} which is {other_ref} in the lockfile."  # noqa: E501
                         )

--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 import json
 import sys
 from dataclasses import dataclass, field
@@ -170,8 +171,17 @@ def update_flake_lock(flake_lock: LockFile) -> LockFile:
     for key, ref in root_inputs.items():
         if isinstance(ref, list):
             continue
+        canonical_node = flake_lock.nodes[ref]
         for node_ref in input_refs.get(key, ()):
-            flake_lock.nodes[node_ref] = flake_lock.nodes[ref]
+            target_node = flake_lock.nodes[node_ref]
+            # Preserve the inputs field (dependency wiring)
+            # Only unify the locked/original content
+            target_node.remaining["locked"] = copy.deepcopy(
+                canonical_node.remaining.get("locked")
+            )
+            target_node.remaining["original"] = copy.deepcopy(
+                canonical_node.remaining.get("original")
+            )
 
     return flake_lock
 

--- a/tests/fixtures/follows_references.json
+++ b/tests/fixtures/follows_references.json
@@ -1,0 +1,92 @@
+{
+  "root": "root",
+  "version": 7,
+  "nodes": {
+    "root": {
+      "inputs": {
+        "a": "a",
+        "dep": "dep_2"
+      }
+    },
+    "a": {
+      "inputs": {
+        "dep": "dep"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "path": "./a",
+        "type": "path"
+      },
+      "original": {
+        "path": "./a",
+        "type": "path"
+      }
+    },
+    "dep": {
+      "inputs": {
+        "subdep": [
+          "a",
+          "subdep"
+        ]
+      },
+      "locked": {
+        "lastModified": 100,
+        "narHash": "sha256-dep1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "dep",
+        "rev": "abc123",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "dep",
+        "type": "github"
+      }
+    },
+    "dep_2": {
+      "inputs": {
+        "subdep": "subdep_2"
+      },
+      "locked": {
+        "lastModified": 200,
+        "narHash": "sha256-dep2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "dep",
+        "rev": "def456",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "dep",
+        "type": "github"
+      }
+    },
+    "subdep": {
+      "inputs": null,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-subAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "path": "./sub",
+        "type": "path"
+      },
+      "original": {
+        "path": "./sub",
+        "type": "path"
+      }
+    },
+    "subdep_2": {
+      "inputs": null,
+      "locked": {
+        "lastModified": 2,
+        "narHash": "sha256-subBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+        "path": "./sub2",
+        "type": "path"
+      },
+      "original": {
+        "path": "./sub2",
+        "type": "path"
+      }
+    }
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,6 +177,33 @@ def test_check_lock_file_success(filename: str) -> None:
         assert check_lock_file(modified_lock)
 
 
+def test_preserve_follows_references() -> None:
+    """Test that follows references in inputs are preserved during unification."""
+    with open("tests/fixtures/follows_references.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+        # precondition: dep and dep_2 have different locked content
+        assert (
+            flake_lock.nodes["dep"].remaining["locked"]
+            != flake_lock.nodes["dep_2"].remaining["locked"]
+        )
+        # precondition: dep has follows reference, dep_2 has direct reference
+        assert flake_lock.nodes["dep"].inputs == {"subdep": ["a", "subdep"]}
+        assert flake_lock.nodes["dep_2"].inputs == {"subdep": "subdep_2"}
+
+        modified_lock = update_flake_lock(flake_lock)
+
+        # postcondition: locked content is now identical
+        assert (
+            modified_lock.nodes["dep"].remaining["locked"]
+            == modified_lock.nodes["dep_2"].remaining["locked"]
+        )
+        # postcondition: inputs structure is preserved (follows vs direct)
+        assert modified_lock.nodes["dep"].inputs == {"subdep": ["a", "subdep"]}
+        assert modified_lock.nodes["dep_2"].inputs == {"subdep": "subdep_2"}
+        # check should pass
+        assert check_lock_file(modified_lock)
+
+
 def test_check_lock_file_fail() -> None:
     """
     This lockfile fails because there are follows beyond the root.


### PR DESCRIPTION
- **test(preserve inputs): add test for preserving follows references**
- **fix(preserve inputs): do not clobber inputs field on content copy**
- **fix(preserve inputs check): compare only locked content in check_lock_file**

Next PR: https://github.com/fzakaria/nix-auto-follow/pull/35

---

**Problem:** After running `nix-auto-follow`, subsequent `nix build` commands
keep adding inputs back to the lockfile, causing instability.

**Root cause:** The version unification logic was copying the entire node
content when making different versions identical. This included copying the
`inputs` field, which clobbered existing follows references:

```python
# Before fix (bad - copies everything including inputs)
target_node = copy.deepcopy(canonical_node)

# After fix (good - only copies version info, preserves inputs wiring)
target_node.remaining["locked"] = copy.deepcopy(canonical_node.remaining["locked"])
target_node.remaining["original"] = copy.deepcopy(canonical_node.remaining["original"])
```

When the `inputs` field was copied, it converted follows references (which are
arrays) into direct references (which are strings), breaking the dependency
chain:

```jsonc
// Before nix-auto-follow
"nuschtosSearch": {
  "inputs": {
    "nixpkgs": ["nixvim", "nixpkgs"]  // follows reference (array)
  }
}

// After nix-auto-follow (BUG - inputs field was clobbered!)
"nuschtosSearch": {
  "inputs": {
    "nixpkgs": "nixpkgs_4"  // now a direct reference (string)
  }
}
```

When Nix evaluates the flake, it checks if the lockfile matches the upstream
flake.nix declarations. It sees that `nuschtosSearch` should follow `nixvim`'s
`nixpkgs` (based on upstream), but the lockfile has a direct reference instead.
Nix detects this inconsistency and regenerates those entries, adding back the
follows references.

The derivation stays identical (same package versions), but the lockfile
structure keeps changing back and forth between direct refs and follows.

**Fix:** Only copy the `locked` and `original` fields during version
unification. Preserve the `inputs` field to maintain the correct dependency
wiring.

**Result:** Lockfile stays stable after `nix-auto-follow` - no spurious inputs
added on subsequent rebuilds.
