### PR TITLE
feat consolidation

### DIFF
--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -123,7 +123,10 @@ def check_lock_file(flake_lock: LockFile) -> bool:
                     if key != other_key:
                         continue
 
-                    if flake_lock.nodes[ref] != flake_lock.nodes[other_ref]:
+                    # Compare only locked content, not inputs wiring
+                    node_locked = flake_lock.nodes[ref].remaining.get("locked")
+                    other_locked = flake_lock.nodes[other_ref].remaining.get("locked")
+                    if node_locked != other_locked:
                         print(
                             f"Node {name} has input {key} pointing to {ref} which is not the same as {other_name}'s {other_key} which is {other_ref} in the lockfile."  # noqa: E501
                         )

--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -176,6 +176,8 @@ def update_flake_lock(flake_lock: LockFile) -> LockFile:
             continue
         canonical_node = flake_lock.nodes[ref]
         for node_ref in input_refs.get(key, ()):
+            if node_ref == ref:
+                continue
             target_node = flake_lock.nodes[node_ref]
             # Preserve the inputs field (dependency wiring)
             # Only unify the locked/original content

--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import copy
 import json
 import sys
 from dataclasses import dataclass, field
@@ -170,8 +171,17 @@ def update_flake_lock(flake_lock: LockFile) -> LockFile:
     for key, ref in root_inputs.items():
         if isinstance(ref, list):
             continue
+        canonical_node = flake_lock.nodes[ref]
         for node_ref in input_refs.get(key, ()):
-            flake_lock.nodes[node_ref] = flake_lock.nodes[ref]
+            target_node = flake_lock.nodes[node_ref]
+            # Preserve the inputs field (dependency wiring)
+            # Only unify the locked/original content
+            target_node.remaining["locked"] = copy.deepcopy(
+                canonical_node.remaining.get("locked")
+            )
+            target_node.remaining["original"] = copy.deepcopy(
+                canonical_node.remaining.get("original")
+            )
 
     return flake_lock
 

--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -12,6 +12,7 @@ class ProgramArguments:
     filename: str = "flake.lock"
     in_place: bool = False
     check: bool = False
+    consolidate: bool = False
 
 
 @dataclass
@@ -98,6 +99,86 @@ class LockFile:
             "root": self.root,
             "version": self.version,
         }
+
+
+def consolidate_flake_lock(flake_lock: LockFile) -> LockFile:
+    """Convert direct references to follows where safe.
+
+    During traversal from root, if a child node has an input matching its
+    parent's input (same key, same locked content), convert to follows.
+    Then garbage collect any unreachable nodes.
+    """
+
+    def traverse(node_name: str, path: list[str]) -> None:
+        node = flake_lock.nodes.get(node_name)
+        if node is None or node.inputs is None:
+            return
+
+        for input_key, input_ref in node.inputs.items():
+            if isinstance(input_ref, list):
+                continue
+
+            child_node = flake_lock.nodes.get(input_ref)
+            if child_node is None or child_node.inputs is None:
+                traverse(input_ref, path + [input_key])
+                continue
+
+            # Only convert children at depth >= 2 (not direct children of root)
+            child_path = path + [input_key]
+            if len(child_path) >= 2:
+                # Check if child's inputs can become follows
+                for child_input_key, child_input_ref in list(child_node.inputs.items()):
+                    if isinstance(child_input_ref, list):
+                        continue
+
+                    # Does parent have same input?
+                    if child_input_key in node.inputs:
+                        parent_input_ref = node.inputs[child_input_key]
+                        if isinstance(parent_input_ref, list):
+                            continue
+
+                        # Compare locked content
+                        child_locked = flake_lock.nodes[child_input_ref].remaining.get(
+                            "locked"
+                        )
+                        parent_locked = flake_lock.nodes[
+                            parent_input_ref
+                        ].remaining.get("locked")
+
+                        if child_locked == parent_locked:
+                            # Convert to follows!
+                            child_node.inputs[child_input_key] = path + [
+                                child_input_key
+                            ]
+
+            # Recurse to children
+            traverse(input_ref, path + [input_key])
+
+    traverse(flake_lock.root, [])
+
+    # Garbage collect unreachable nodes
+    reachable: set[str] = {flake_lock.root}
+
+    def mark_reachable(node_name: str) -> None:
+        node = flake_lock.nodes.get(node_name)
+        if node is None or node.inputs is None:
+            return
+
+        for input_ref in node.inputs.values():
+            if isinstance(input_ref, list):
+                continue
+            if input_ref not in reachable:
+                reachable.add(input_ref)
+                mark_reachable(input_ref)
+
+    mark_reachable(flake_lock.root)
+
+    # Remove unreachable nodes
+    flake_lock.nodes = {
+        name: node for name, node in flake_lock.nodes.items() if name in reachable
+    }
+
+    return flake_lock
 
 
 def check_lock_file(flake_lock: LockFile) -> bool:
@@ -217,6 +298,11 @@ def start(
         action="store_true",
         help="Checks whether all entries in your lockfile are follows or equivalent.",
     )
+    parser.add_argument(
+        "--consolidate",
+        action="store_true",
+        help="Convert direct references to follows and remove duplicate nodes.",
+    )
 
     program_args: ProgramArguments = parser.parse_args(
         args, namespace=ProgramArguments()
@@ -239,9 +325,15 @@ def start(
             print("All ok!")
             return
 
-    modified_data = json.dumps(
-        update_flake_lock(LockFile.from_dict(flake_lock_json)).to_dict(), indent=2
-    )
+    # Apply version unification
+    flake_lock = LockFile.from_dict(flake_lock_json)
+    flake_lock = update_flake_lock(flake_lock)
+
+    # Apply consolidation if requested
+    if program_args.consolidate:
+        flake_lock = consolidate_flake_lock(flake_lock)
+
+    modified_data = json.dumps(flake_lock.to_dict(), indent=2)
 
     if program_args.in_place:
         if program_args.filename == "-":

--- a/tests/fixtures/follows_references.json
+++ b/tests/fixtures/follows_references.json
@@ -1,0 +1,92 @@
+{
+  "root": "root",
+  "version": 7,
+  "nodes": {
+    "root": {
+      "inputs": {
+        "a": "a",
+        "dep": "dep_2"
+      }
+    },
+    "a": {
+      "inputs": {
+        "dep": "dep"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "path": "./a",
+        "type": "path"
+      },
+      "original": {
+        "path": "./a",
+        "type": "path"
+      }
+    },
+    "dep": {
+      "inputs": {
+        "subdep": [
+          "a",
+          "subdep"
+        ]
+      },
+      "locked": {
+        "lastModified": 100,
+        "narHash": "sha256-dep1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "dep",
+        "rev": "abc123",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "dep",
+        "type": "github"
+      }
+    },
+    "dep_2": {
+      "inputs": {
+        "subdep": "subdep_2"
+      },
+      "locked": {
+        "lastModified": 200,
+        "narHash": "sha256-dep2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "dep",
+        "rev": "def456",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "dep",
+        "type": "github"
+      }
+    },
+    "subdep": {
+      "inputs": null,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-subAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "path": "./sub",
+        "type": "path"
+      },
+      "original": {
+        "path": "./sub",
+        "type": "path"
+      }
+    },
+    "subdep_2": {
+      "inputs": null,
+      "locked": {
+        "lastModified": 2,
+        "narHash": "sha256-subBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+        "path": "./sub2",
+        "type": "path"
+      },
+      "original": {
+        "path": "./sub2",
+        "type": "path"
+      }
+    }
+  }
+}

--- a/tests/fixtures/nested_follows.json
+++ b/tests/fixtures/nested_follows.json
@@ -1,0 +1,120 @@
+{
+  "root": "root",
+  "version": 7,
+  "nodes": {
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "parent": "parent"
+      }
+    },
+    "parent": {
+      "inputs": {
+        "utils": "utils",
+        "child": "child",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-parentAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "path": "./parent",
+        "type": "path"
+      },
+      "original": {
+        "path": "./parent",
+        "type": "path"
+      }
+    },
+    "child": {
+      "inputs": {
+        "utils": "utils_2",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-childAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "path": "./child",
+        "type": "path"
+      },
+      "original": {
+        "path": "./child",
+        "type": "path"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 100,
+        "narHash": "sha256-nixpkgsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "nixpkgs",
+        "rev": "abc123",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 100,
+        "narHash": "sha256-nixpkgsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "nixpkgs",
+        "rev": "abc123",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 100,
+        "narHash": "sha256-nixpkgsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "nixpkgs",
+        "rev": "abc123",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 200,
+        "narHash": "sha256-utilsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "utils",
+        "rev": "def456",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "utils",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "locked": {
+        "lastModified": 200,
+        "narHash": "sha256-utilsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "utils",
+        "rev": "def456",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "utils",
+        "type": "github"
+      }
+    }
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,3 +262,36 @@ def test_node_keys_sorted() -> None:
         assert list(modified_lock_json["nodes"].keys()) == sorted(
             modified_lock_json["nodes"].keys()
         )
+
+
+def test_consolidation() -> None:
+    """Test consolidation converts direct refs to follows."""
+    from nix_auto_follow.cli import consolidate_flake_lock
+
+    # Use the nested_follows fixture which has duplicate nodes with direct refs
+    with open("tests/fixtures/nested_follows.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+
+        # Precondition: child has direct refs to utils_2 and nixpkgs_3
+        child_node = flake_lock.nodes["child"]
+        assert child_node.inputs is not None
+        assert child_node.inputs["utils"] == "utils_2"
+        assert child_node.inputs["nixpkgs"] == "nixpkgs_3"
+
+        # First apply version unification
+        flake_lock = update_flake_lock(flake_lock)
+
+        # Then apply consolidation
+        flake_lock = consolidate_flake_lock(flake_lock)
+
+        # Postcondition: child should now use follows refs to parent's inputs
+        child_node = flake_lock.nodes["child"]
+        assert child_node.inputs is not None
+
+        # Child's utils should follow parent's utils
+        assert isinstance(child_node.inputs["utils"], list)
+        assert child_node.inputs["utils"] == ["parent", "utils"]
+
+        # Child's nixpkgs should follow parent's nixpkgs
+        assert isinstance(child_node.inputs["nixpkgs"], list)
+        assert child_node.inputs["nixpkgs"] == ["parent", "nixpkgs"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,6 +177,33 @@ def test_check_lock_file_success(filename: str) -> None:
         assert check_lock_file(modified_lock)
 
 
+def test_preserve_follows_references() -> None:
+    """Test that follows references in inputs are preserved during unification."""
+    with open("tests/fixtures/follows_references.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+        # precondition: dep and dep_2 have different locked content
+        assert (
+            flake_lock.nodes["dep"].remaining["locked"]
+            != flake_lock.nodes["dep_2"].remaining["locked"]
+        )
+        # precondition: dep has follows reference, dep_2 has direct reference
+        assert flake_lock.nodes["dep"].inputs == {"subdep": ["a", "subdep"]}
+        assert flake_lock.nodes["dep_2"].inputs == {"subdep": "subdep_2"}
+
+        modified_lock = update_flake_lock(flake_lock)
+
+        # postcondition: locked content is now identical
+        assert (
+            modified_lock.nodes["dep"].remaining["locked"]
+            == modified_lock.nodes["dep_2"].remaining["locked"]
+        )
+        # postcondition: inputs structure is preserved (follows vs direct)
+        assert modified_lock.nodes["dep"].inputs == {"subdep": ["a", "subdep"]}
+        assert modified_lock.nodes["dep_2"].inputs == {"subdep": "subdep_2"}
+        # check should pass
+        assert check_lock_file(modified_lock)
+
+
 def test_check_lock_file_fail() -> None:
     """
     This lockfile fails because there are follows beyond the root.


### PR DESCRIPTION
Prev PR: https://github.com/fzakaria/nix-auto-follow/pull/34
- **test(preserve inputs): add test for preserving follows references**
- **fix(preserve inputs): do not clobber inputs field on content copy**
- **fix(preserve inputs check): compare only locked content in check_lock_file**

<sup>^</sup> Above three from prev-pr, Merge these first, please!

---

This PR:

- **test(consolidation): add test for follows conversion**
- **fix(node processing): skip self**
- **feat(consolidation): convert direct refs to follows**

---

**Problem:** "Malignant" lockfiles contain duplicate nodes with direct
references where follows references should be used. This happens when multiple
flake inputs depend on the same upstream package (like nixpkgs), but each has
its own separate node in the lockfile instead of using follows to share a
single node. This wastes space, makes lockfiles harder to maintain, and defeats
the purpose of follows references.

**Solution:** Add `--consolidate` flag that heuristically converts direct
references to follows references where it's safe to do so. The algorithm:

1. Traverses the lockfile from root, building up the dependency tree
2. For each child node at depth >= 2, checks if its inputs match its parent's
   inputs (same key, same locked content)
3. If they match, converts the direct reference to a follows path
4. After conversion, garbage collects any nodes that became unreachable

A direct reference can only be safely converted to a follows if:

- The child is at depth >= 2 (not a direct child of root)
- The parent has an input with the same key
- Both inputs point to nodes with identical locked content

**Example:**

```jsonc
// Before: malignant lockfile with duplicates
{
  "nodes": {
    "root": {"inputs": {"parent": "parent"}},
    "parent": {
      "inputs": {
        "nixpkgs": "nixpkgs",
        "utils": "utils",
        "child": "child"
      }
    },
    "child": {
      "inputs": {
        "nixpkgs": "nixpkgs_2",  // DUPLICATE (same locked content as parent's nixpkgs)
        "utils": "utils_2"       // DUPLICATE (same locked content as parent's utils)
      }
    },
    "nixpkgs": {"locked": {"rev": "abc123", ...}},
    "nixpkgs_2": {"locked": {"rev": "abc123", ...}},  // Exact same content!
    "utils": {"locked": {"rev": "def456", ...}},
    "utils_2": {"locked": {"rev": "def456", ...}}     // Exact same content!
  }
}
```

```jsonc
// After consolidation: follows references + garbage collection
{
  "nodes": {
    "root": {"inputs": {"parent": "parent"}},
    "parent": {
      "inputs": {
        "nixpkgs": "nixpkgs",
        "utils": "utils",
        "child": "child"
      }
    },
    "child": {
      "inputs": {
        "nixpkgs": ["parent", "nixpkgs"],  // Follows parent's nixpkgs!
        "utils": ["parent", "utils"]       // Follows parent's utils!
      }
    },
    "nixpkgs": {"locked": {"rev": "abc123", ...}},
    "utils": {"locked": {"rev": "def456", ...}}
    // nixpkgs_2 and utils_2 removed by garbage collection
  }
}
```

The consolidation establishes proper dependency chains: child explicitly
depends on parent's versions of nixpkgs and utils, rather than having separate
duplicate copies. When parent updates its nixpkgs, child automatically gets the
update through the follows reference.

**Result:** Tested on my nixvim config: 61 nodes → 51 nodes (10 duplicates
eliminated)!
Smaller lockfiles with proper follows chains that match the intended dependency
structure.
