### PR TITLE
Add --ignore input flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ flake-parts.url = "github:hercules-ci/flake-parts";
 ❯ auto-follow -i --ignore flake-parts
 ```
 
-`--check` honours the same flag, so `auto-follow -c --ignore flake-parts` will not complain about the protected subtree.
+`--check` honors the same flag, so `auto-follow -c --ignore flake-parts` will not complain about the protected subtree.
 
 ```console
 ❯ auto-follow -c

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ All ok!
 
 This will fail (exit code 1) if not everything can be deduped.
 
+## Ignoring an input
+
+If do _not_ want to override some input, you can use `--ignore` with a root input.
+The entire input subtree will not be touched by nix-auto-follow.
+
+```console
+❯ cat flake.nix | grep flake-parts
+flake-parts.url = "github:hercules-ci/flake-parts";
+
+❯ auto-follow -i --ignore flake-parts
+```
+
+`--check` honours the same flag, so `auto-follow -c --ignore flake-parts` will not complain about the protected subtree.
+
 ```console
 ❯ auto-follow -c
 Node a has input nixpkgs pointing to nixpkgs_2 which is not the same as b's nixpkgs which is nixpkgs_3 in the lockfile.

--- a/src/nix_auto_follow/cli.py
+++ b/src/nix_auto_follow/cli.py
@@ -11,6 +11,7 @@ class ProgramArguments:
     filename: str = "flake.lock"
     in_place: bool = False
     check: bool = False
+    ignore: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -99,7 +100,44 @@ class LockFile:
         }
 
 
-def check_lock_file(flake_lock: LockFile) -> bool:
+def collect_ignored_nodes(flake_lock: LockFile, ignore: list[str]) -> set[str]:
+    """
+    Return every node reachable from the ignored inputs.
+    """
+    root_inputs = flake_lock.root_node.inputs or {}
+
+    pending: list[str] = []
+    for name in ignore:
+        ref = root_inputs.get(name)
+        if ref is None:
+            print(
+                f"Warning: --ignore '{name}' does not match any root input.",
+                file=sys.stderr,
+            )
+            continue
+        if isinstance(ref, list):
+            continue
+        pending.append(ref)
+
+    ignored: set[str] = set()
+    while pending:
+        node_name = pending.pop()
+        if node_name in ignored:
+            continue
+        ignored.add(node_name)
+        node = flake_lock.nodes.get(node_name)
+        if node is None or node.inputs is None:
+            continue
+        for child_ref in node.inputs.values():
+            if isinstance(child_ref, list):
+                continue
+            pending.append(child_ref)
+
+    return ignored
+
+
+def check_lock_file(flake_lock: LockFile, ignored: set[str] | None = None) -> bool:
+    ignored = ignored or set()
 
     for name, node in flake_lock.nodes.items():
 
@@ -110,6 +148,9 @@ def check_lock_file(flake_lock: LockFile) -> bool:
             if isinstance(ref, list):
                 continue
 
+            if ref in ignored:
+                continue
+
             for other_name, other_node in flake_lock.nodes.items():
 
                 if other_node.inputs is None:
@@ -117,6 +158,9 @@ def check_lock_file(flake_lock: LockFile) -> bool:
 
                 for other_key, other_ref in other_node.inputs.items():
                     if isinstance(other_ref, list):
+                        continue
+
+                    if other_ref in ignored:
                         continue
 
                     if key != other_key:
@@ -134,7 +178,11 @@ def check_lock_file(flake_lock: LockFile) -> bool:
     return True
 
 
-def update_flake_lock(flake_lock: LockFile) -> LockFile:
+def update_flake_lock(
+    flake_lock: LockFile, ignored: set[str] | None = None
+) -> LockFile:
+    ignored = ignored or set()
+
     # Start at root
     root_inputs = flake_lock.root_node.inputs
 
@@ -154,6 +202,8 @@ def update_flake_lock(flake_lock: LockFile) -> LockFile:
             continue
         for node_input_key, node_input_ref in node.inputs.items():
             if isinstance(node_input_ref, list):
+                continue
+            if node_input_ref in ignored:
                 continue
             input_refs.setdefault(node_input_key, []).append(node_input_ref)
 
@@ -202,6 +252,14 @@ def start(
         action="store_true",
         help="Checks whether all entries in your lockfile are follows or equivalent.",
     )
+    parser.add_argument(
+        "--ignore",
+        "-I",
+        action="append",
+        default=[],
+        metavar="INPUT",
+        help="Root input(s) to be ignored.",
+    )
 
     program_args: ProgramArguments = parser.parse_args(
         args, namespace=ProgramArguments()
@@ -216,16 +274,18 @@ def start(
 
     # Load the JSON data from the input
     flake_lock_json: dict[str, Any] = json.loads(input_data)
+    flake_lock = LockFile.from_dict(flake_lock_json)
+    ignored = collect_ignored_nodes(flake_lock, program_args.ignore)
 
     if program_args.check:
-        if not check_lock_file(LockFile.from_dict(flake_lock_json)):
+        if not check_lock_file(flake_lock, ignored):
             exit(1)
         else:
             print("All ok!")
             return
 
     modified_data = json.dumps(
-        update_flake_lock(LockFile.from_dict(flake_lock_json)).to_dict(), indent=2
+        update_flake_lock(flake_lock, ignored).to_dict(), indent=2
     )
 
     if program_args.in_place:

--- a/tests/fixtures/ignore_subtree.json
+++ b/tests/fixtures/ignore_subtree.json
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "dep": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_pinned"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-dDdEpKBksdAQ8oTjZ8sN8YnYnYnYnYnYnYnYnYnYnY=",
+        "path": "./dep",
+        "type": "path"
+      },
+      "original": {
+        "path": "./dep",
+        "type": "path"
+      }
+    },
+    "nixpkgs_other": {
+      "locked": {
+        "lastModified": 1722372011,
+        "narHash": "sha256-B2xRiC3NEJy/82ugtareBkRqEkPGpMyjaLxaR8LBxNs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cf05eeada35e122770c5c14add958790fcfcbef5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_pinned": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_root": {
+      "locked": {
+        "lastModified": 1730000000,
+        "narHash": "sha256-rOoTrOoTrOoTrOoTrOoTrOoTrOoTrOoTrOoTrOoTrOo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0000000000000000000000000000000000000000",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "other": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_other"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-oThErOThErOThErOThErOThErOThErOThErOThErOO=",
+        "path": "./other",
+        "type": "path"
+      },
+      "original": {
+        "path": "./other",
+        "type": "path"
+      }
+    },
+    "pinned": {
+      "inputs": {
+        "dep": "dep"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-pInNeDpInNeDpInNeDpInNeDpInNeDpInNeDpInNeDO=",
+        "path": "./pinned",
+        "type": "path"
+      },
+      "original": {
+        "path": "./pinned",
+        "type": "path"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_root",
+        "other": "other",
+        "pinned": "pinned"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from nix_auto_follow.cli import (
     LockFile,
     Node,
     check_lock_file,
+    collect_ignored_nodes,
     start,
     update_flake_lock,
 )
@@ -219,6 +220,77 @@ def test_top_level_keys_sorted() -> None:
 
         # postcondition: keys are sorted in modified file
         assert list(modified_lock_json.keys()) == sorted(modified_lock_json.keys())
+
+
+def test_collect_ignored_nodes_transitive_closure() -> None:
+    with open("tests/fixtures/ignore_subtree.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+        ignored = collect_ignored_nodes(flake_lock, ["pinned"])
+        # the whole subtree reachable from the "pinned" root input, including
+        # the nested (depth-2) nixpkgs:
+        assert ignored == {"pinned", "dep", "nixpkgs_pinned"}
+
+
+def test_collect_ignored_nodes_unknown_input_warns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with open("tests/fixtures/ignore_subtree.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+        assert collect_ignored_nodes(flake_lock, ["nonexistent"]) == set()
+        assert "does not match any root input" in capsys.readouterr().err
+
+
+def test_ignore_protects_subtree_but_collapses_siblings() -> None:
+    with open("tests/fixtures/ignore_subtree.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+        # precondition: every nixpkgs differs.
+        assert flake_lock.nodes["nixpkgs_pinned"] != flake_lock.nodes["nixpkgs_root"]
+        assert flake_lock.nodes["nixpkgs_other"] != flake_lock.nodes["nixpkgs_root"]
+
+        ignored = collect_ignored_nodes(flake_lock, ["pinned"])
+        modified_lock = update_flake_lock(flake_lock, ignored)
+
+        # the protected subtree keeps its own pin ...
+        assert (
+            modified_lock.nodes["nixpkgs_pinned"] != modified_lock.nodes["nixpkgs_root"]
+        )
+        # ... while the non-ignored sibling still collapses onto root.
+        assert (
+            modified_lock.nodes["nixpkgs_other"] == modified_lock.nodes["nixpkgs_root"]
+        )
+
+
+def test_ignore_default_collapses_everything() -> None:
+    with open("tests/fixtures/ignore_subtree.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+        # without an ignore list, both subtrees collapse onto root.
+        modified_lock = update_flake_lock(flake_lock)
+        assert (
+            modified_lock.nodes["nixpkgs_pinned"] == modified_lock.nodes["nixpkgs_root"]
+        )
+        assert (
+            modified_lock.nodes["nixpkgs_other"] == modified_lock.nodes["nixpkgs_root"]
+        )
+
+
+def test_check_lock_file_respects_ignore() -> None:
+    with open("tests/fixtures/ignore_subtree.json") as f:
+        flake_lock = LockFile.from_dict(json.load(f))
+        ignored = collect_ignored_nodes(flake_lock, ["pinned"])
+        modified_lock = update_flake_lock(flake_lock, ignored)
+        # with the subtree ignored the remaining inputs are consistent ...
+        assert check_lock_file(modified_lock, ignored)
+        # ... but a plain check still flags the intentionally-kept pin.
+        assert not check_lock_file(modified_lock)
+
+
+def test_start_with_ignore() -> None:
+    with open("tests/fixtures/ignore_subtree.json") as f:
+        stdout = io.StringIO()
+        start(args=["--ignore", "pinned", "-"], stdin=f, stdout=stdout)
+        flake_lock = LockFile.from_dict(json.loads(stdout.getvalue()))
+        assert flake_lock.nodes["nixpkgs_pinned"] != flake_lock.nodes["nixpkgs_root"]
+        assert flake_lock.nodes["nixpkgs_other"] == flake_lock.nodes["nixpkgs_root"]
 
 
 def test_node_keys_sorted() -> None:


### PR DESCRIPTION
Similar to issue #19, I needed a way to ignore a node from the auto follower.

I added a flag `--ignore` or `-I` that allows for ignoring an input based on it's name. The nodes entire sub-tree is ignored along with the root.

If this feature does not fit the scope of the project, feel free to close.

### Purpose
This allows you to selectively respect a flake author's pinning should their package break if the input versions break.

### Usage
```console
❯ auto-follow -i --ignore flake-parts
```

The flag is repeatable:
```console
❯ auto-follow -i --ignore flake-parts --ignore nix-darwin
```

And respects checks:
```
❯ auto-follow -c --ignore flake-parts
All ok!
```
### Tests
I added six tests that *should* be comprehensive for the feature.